### PR TITLE
Using tables from config in Import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Voyager - Export
+# Voyager - Export/Import
+
+Commands for export/import Voyager menu and config
 
 
 ## Introduction
@@ -13,6 +15,12 @@ This command will export all Voyager related tables into `.json` files into the 
 ### `artisan voyager:import`
 
 This command will import all data from the `config` folder into the Voyager related tables.
+
+Additional options:
+
+`--clear | -c` — for Voyager tables before import
+
+`--cache-reset | -r` — for reset and recreate Voyager menu
 
 ### `artisan voyager:clear`
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This command will import all data from the `config` folder into the Voyager rela
 
 Made a mistake? Want to start again? Remove all exported data with `voyager:clean`.
 
+## Install
+
+`composer require slice-of-code-it-consultancy/voyager-config`
+
+`php artisan vendor:publish --provider=MadeByBob\\VoyagerConfig\\VoyagerConfigServiceProvider`
+
 ## Commands explained
 
 This documentation is still to do. Try `artisan list` and `artisan voyager:export --help` for more information

--- a/config/voyager-config.php
+++ b/config/voyager-config.php
@@ -12,15 +12,15 @@ return [
 
   // list of the tables which belong to Voyager to export
   'tables' => [
-    'data_rows',
-    'data_types',
-    'menus',
-    'menu_items',
-    'permissions',
-    'permission_role',
-    'roles',
-    'settings',
-    'translations',
+      'data_types',
+      'data_rows',
+      'menus',
+      'menu_items',
+      'permissions',
+      'roles',
+      'permission_role',
+      'settings',
+      'translations',
   ]
 
 ];

--- a/src/Console/Commands/VoyagerClearCommand.php
+++ b/src/Console/Commands/VoyagerClearCommand.php
@@ -20,7 +20,7 @@ class VoyagerClearCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Clears Voyager\'s data from the config folder';
+    protected $description = 'Clears Voyager\'s exported config data from the config folder';
 
     /**
      * Create a new command instance.

--- a/src/Console/Commands/VoyagerImportCommand.php
+++ b/src/Console/Commands/VoyagerImportCommand.php
@@ -12,7 +12,9 @@ class VoyagerImportCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'voyager:import';
+    protected $signature = 'voyager:import
+            {--c|clear : Clear table before import}
+            ';
 
     /**
      * The console command description.
@@ -38,11 +40,24 @@ class VoyagerImportCommand extends Command
      */
     public function handle()
     {
+        $tables = config('voyager-config.tables');
+
+        if($this->option('clear')){
+            $this->info("Clear Voyager config ...");
+
+            DB::beginTransaction();
+            DB::select('SET FOREIGN_KEY_CHECKS = 0');
+            foreach ($tables as $table) {
+
+                DB::table($table)->truncate();
+            }
+            DB::select('SET FOREIGN_KEY_CHECKS = 1');
+            DB::commit();
+        }
+
         DB::beginTransaction();
 
         $this->info("Starting Voyager config import ...");
-
-        $tables = config('voyager-config.tables');
 
         foreach ($tables as $table) {
             $this->line("Importing {$table}...");
@@ -50,7 +65,7 @@ class VoyagerImportCommand extends Command
             // get configuration files created by `voyager:export`
             $conf_entries = $this->getConfigurationEntries($table);
 
-            // check valid config entries 
+            // check valid config entries
             if (empty($conf_entries)) {
                 $this->info("{$table} is empty");
                 // skip importing configuration for table.
@@ -69,7 +84,7 @@ class VoyagerImportCommand extends Command
 
     /**
      * Get the contents of the table configuration file.
-     * 
+     *
      * @return string
      */
     protected function getConfigFileContent($file_path) {
@@ -90,7 +105,7 @@ class VoyagerImportCommand extends Command
 
     /**
      * Parse table configuration for DB insert.
-     * 
+     *
      * @return array
      */
     protected function parseConfigFileContent($json_content) {
@@ -113,12 +128,12 @@ class VoyagerImportCommand extends Command
 
     /**
      * Get the contents of the table configuration and parse for DB insert.
-     * 
+     *
      * @return array
      */
     protected function getConfigurationEntries($table) {
         $folder = config('voyager-config.path') . '/' . config('voyager-config.folder');
-        
+
         // generate file path created by `voyager:export`
         $file_path = $folder . '/' . $table . '.json';
         // pass current configuration path

--- a/src/Console/Commands/VoyagerImportCommand.php
+++ b/src/Console/Commands/VoyagerImportCommand.php
@@ -117,8 +117,10 @@ class VoyagerImportCommand extends Command
      * @return array
      */
     protected function getConfigurationEntries($table) {
+        $folder = config('voyager-config.path') . '/' . config('voyager-config.folder');
+        
         // generate file path created by `voyager:export`
-        $file_path = 'config/voyager/' . $table . '.json';
+        $file_path = $folder . '/' . $table . '.json';
         // pass current configuration path
         $json_content = $this->getConfigFileContent($file_path);
         // exit if invalid file

--- a/src/Console/Commands/VoyagerImportCommand.php
+++ b/src/Console/Commands/VoyagerImportCommand.php
@@ -3,6 +3,7 @@
 namespace MadeByBob\VoyagerConfig\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class VoyagerImportCommand extends Command
@@ -13,7 +14,8 @@ class VoyagerImportCommand extends Command
      * @var string
      */
     protected $signature = 'voyager:import
-            {--c|clear : Clear table before import}
+            {--c|clear : Clear tables before import}
+            {--cache : Reset menu cache }
             ';
 
     /**
@@ -80,6 +82,18 @@ class VoyagerImportCommand extends Command
         DB::commit();
 
         $this->info("Importing Voyager configuration successful!");
+
+        if($this->option('cache')) {
+
+            $this->info("Resetting menu cache...");
+
+            $menus = DB::table('menus')->get('name');
+            foreach ($menus as $menu){
+                $this->line("{$menu->name}");
+
+                Cache::forget('voyager_menu_' . $menu->name);
+            }
+        }
     }
 
     /**

--- a/src/Console/Commands/VoyagerImportCommand.php
+++ b/src/Console/Commands/VoyagerImportCommand.php
@@ -15,7 +15,7 @@ class VoyagerImportCommand extends Command
      */
     protected $signature = 'voyager:import
             {--c|clear : Clear tables before import}
-            {--cache : Reset menu cache }
+            {--r|cache-reset : Reset menu cache }
             ';
 
     /**
@@ -47,14 +47,12 @@ class VoyagerImportCommand extends Command
         if($this->option('clear')){
             $this->info("Clear Voyager config ...");
 
-//            DB::beginTransaction();
             DB::select('SET FOREIGN_KEY_CHECKS = 0');
             foreach ($tables as $table) {
 
                 DB::table($table)->truncate();
             }
             DB::select('SET FOREIGN_KEY_CHECKS = 1');
-//            DB::commit();
         }
 
         DB::beginTransaction();
@@ -83,7 +81,7 @@ class VoyagerImportCommand extends Command
 
         $this->info("Importing Voyager configuration successful!");
 
-        if($this->option('cache')) {
+        if($this->option('cache-reset')) {
 
             $this->info("Resetting menu cache...");
 

--- a/src/Console/Commands/VoyagerImportCommand.php
+++ b/src/Console/Commands/VoyagerImportCommand.php
@@ -22,23 +22,6 @@ class VoyagerImportCommand extends Command
     protected $description = 'Import all data from the config folder into the Voyager related tables.';
 
     /**
-     * The list of tables ordered for Foreign Key checks compliance.
-     *
-     * @var array
-     */
-    protected $tables = [
-        'data_types',
-        'data_rows',
-        'roles',
-        'permissions',
-        'permission_role',
-        'menus',
-        'menu_items',
-        'settings',
-        'translations',
-    ];
-
-    /**
      * Create a new command instance.
      *
      * @return void
@@ -59,7 +42,9 @@ class VoyagerImportCommand extends Command
 
         $this->info("Starting Voyager config import ...");
 
-        foreach ($this->tables as $table) {
+        $tables = config('voyager-config.tables');
+
+        foreach ($tables as $table) {
             $this->line("Importing {$table}...");
 
             // get configuration files created by `voyager:export`
@@ -67,9 +52,9 @@ class VoyagerImportCommand extends Command
 
             // check valid config entries 
             if (empty($conf_entries)) {
-                $this->info("DB changes are reverted.");
-                // stop importing configuration.
-                return;
+                $this->info("{$table} is empty");
+                // skip importing configuration for table.
+                continue;
             }
 
             // execute insert on successful parsing

--- a/src/Console/Commands/VoyagerImportCommand.php
+++ b/src/Console/Commands/VoyagerImportCommand.php
@@ -47,14 +47,14 @@ class VoyagerImportCommand extends Command
         if($this->option('clear')){
             $this->info("Clear Voyager config ...");
 
-            DB::beginTransaction();
+//            DB::beginTransaction();
             DB::select('SET FOREIGN_KEY_CHECKS = 0');
             foreach ($tables as $table) {
 
                 DB::table($table)->truncate();
             }
             DB::select('SET FOREIGN_KEY_CHECKS = 1');
-            DB::commit();
+//            DB::commit();
         }
 
         DB::beginTransaction();


### PR DESCRIPTION
In Import command now uses tables from config file. Import is possible for tables without entities.
And add a tag 1.0.0, please.